### PR TITLE
Helm based Kubernetes Deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ Thumbs.db
 # Logs
 logs/
 *.log
+
+entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -209,5 +209,5 @@ docker run -it -e RUN_CLIENT=true deda
 Enjoy chatting!
 
 
-### 4. Run DEDA in Kubernetes Cluster:
+### 5. Run DEDA in Kubernetes Cluster:
 For deployment on a Kubernetes cluster, follow the [Helm deployment guide](./helm/README.md).

--- a/README.md
+++ b/README.md
@@ -210,4 +210,4 @@ Enjoy chatting!
 
 
 ### 4. Run DEDA in Kubernetes Cluster:
-For deployment on a Kubernetes cluster, follow the [Helm deployment guide](./helm/README,md).
+For deployment on a Kubernetes cluster, follow the [Helm deployment guide](./helm/README.md).

--- a/README.md
+++ b/README.md
@@ -197,13 +197,13 @@ ENV OPENAI_API_KEY=sk-proj-XXXX
 Run the following command to build the docker image
 
 ```
-docker build --no-cache -t mcp_app .
+docker build --no-cache -t deda .
 ```
 
 To test
 
 ```
-docker run -it mcp_app
+docker run -it -e RUN_CLIENT=true deda
 ```
 
 Enjoy chatting!

--- a/README.md
+++ b/README.md
@@ -207,3 +207,7 @@ docker run -it -e RUN_CLIENT=true deda
 ```
 
 Enjoy chatting!
+
+
+### 4. Run DEDA in Kubernetes Cluster:
+For deployment on a Kubernetes cluster, follow the [Helm deployment guide](./helm/README,md).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,10 @@ python -m drug_discovery_agent.interfaces.mcp.server &
 # ---- Give the server a few seconds, need to be replace with "http://localhost:8080/health" api later, Retry until http://localhost:8080/health returns 200 ----
 sleep 5
 
-# ---- Start MCP Client ----
-echo "Starting MCP client..."
-python -m drug_discovery_agent.interfaces.mcp.client
+# ---- Optionally Start MCP Client ----
+if [ -n "$RUN_CLIENT" ]; then
+  echo "RUN_CLIENT is set — starting MCP client..."
+  python -m drug_discovery_agent.interfaces.mcp.client
+else
+  wait 
+fi

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,81 @@
+# 🧠 Helm Installation Guideline — DEDA: Drug Evaluation & Discovery Agent
+
+This guide explains how to install and run **DEDA** using Helm, both locally and in a KIND (Kubernetes-in-Docker) cluster.
+
+---
+
+## 🧩 1. Prerequisites
+Make sure you have the following installed:
+- **Docker**
+- **Helm**
+- **KIND** — for local Kubernetes testing
+
+---
+
+## 🧱 2. Run DEDA locally (recommended)
+
+Inside `entrypoint.sh` set your OPENAI_API_KEY. 
+
+Navigate to the Helm directory inside the project:
+```bash
+cd deda-drug-evaluation-and-discovery-agent/helm
+```
+
+Build docker image:
+```bash
+docker build --no-cache -t deda ..
+```
+
+Then verify that the Docker images is built successfully:
+```bash
+docker images
+
+
+> ⚠️ **Important:**  
+> We **do not recommend embedding your OpenAI API key inside the Docker image**.  
+> Always run the container locally where you can safely manage environment variables.  
+> If you maintain a **private Docker registry**, you can build and push your own image using:
+> ```bash
+> docker build -t <your-registry>/deda:latest .
+> docker push <your-registry>/deda:latest
+> ```
+> Please contact us for assistance if you’d like to set up private image hosting.
+
+---
+
+## 🧰 3. Running DEDA with KIND (for testing)
+If you’d like to see how DEDA runs inside a Kubernetes cluster managed by **KIND**, follow these steps:
+
+### Step 1 — Install KIND
+Follow installation instructions from: [https://kind.sigs.k8s.io](https://kind.sigs.k8s.io)
+
+### Step 2 — Create a cluster
+```bash
+kind create cluster
+```
+
+### Step 3 — Load the local Docker image into KIND
+```bash
+kind load docker-image deda:latest
+```
+
+### Step 4 — Deploy using Helm
+Once the image is loaded, install the Helm chart:
+```bash
+helm install deda ./deda
+```
+
+You can verify the deployment:
+```bash
+kubectl get pods
+```
+
+---
+
+## ✅ 4. Summary
+
+| Mode | Command | Notes |
+|------|----------|-------|
+| **Local Docker (recommended)** | `helm install deda ./deda` | Keeps API key private |
+| **KIND cluster** | `kind load docker-image deda:latest` → `helm install deda ./deda` | For Kubernetes testing |
+| **Private registry** | `docker push <your-registry>/deda:latest` | Contact us for setup help |

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,7 @@
 # 🧠 Helm Installation Guideline — DEDA: Drug Evaluation & Discovery Agent
 
-This guide explains how to install and run **DEDA** using Helm, both locally and in a KIND (Kubernetes-in-Docker) cluster.
+This guide explains how to install and run DEDA as a Kubernetes Pod using Helm.
+Feel free to change the Helm template as necessary.
 
 ---
 
@@ -14,7 +15,7 @@ Make sure you have the following installed:
 
 ## 🧱 2. Run DEDA locally (recommended)
 
-Inside `entrypoint.sh` set your OPENAI_API_KEY. 
+Inside `entrypoint.sh` set your `OPENAI_API_KEY`. 
 
 Navigate to the Helm directory inside the project:
 ```bash
@@ -39,7 +40,8 @@ docker images
 > docker build -t <your-registry>/deda:latest .
 > docker push <your-registry>/deda:latest
 > ```
-> Please contact us for assistance if you’d like to set up private image hosting.
+> And then update the `values.yaml` accordingly.
+
 
 ---
 
@@ -69,13 +71,3 @@ You can verify the deployment:
 ```bash
 kubectl get pods
 ```
-
----
-
-## ✅ 4. Summary
-
-| Mode | Command | Notes |
-|------|----------|-------|
-| **Local Docker (recommended)** | `helm install deda ./deda` | Keeps API key private |
-| **KIND cluster** | `kind load docker-image deda:latest` → `helm install deda ./deda` | For Kubernetes testing |
-| **Private registry** | `docker push <your-registry>/deda:latest` | Contact us for setup help |

--- a/helm/README.md
+++ b/helm/README.md
@@ -30,7 +30,7 @@ Then verify that the Docker images is built successfully:
 ```bash
 docker images
 
-
+```
 > ⚠️ **Important:**  
 > We **do not recommend embedding your OpenAI API key inside the Docker image**.  
 > Always run the container locally where you can safely manage environment variables.  

--- a/helm/deda/.helmignore
+++ b/helm/deda/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/deda/Chart.yaml
+++ b/helm/deda/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: deda
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/helm/deda/templates/NOTES.txt
+++ b/helm/deda/templates/NOTES.txt
@@ -1,0 +1,35 @@
+1. Get the application URL by running these commands:
+{{- if .Values.httpRoute.enabled }}
+{{- if .Values.httpRoute.hostnames }}
+    export APP_HOSTNAME={{ .Values.httpRoute.hostnames | first }}
+{{- else }}
+    export APP_HOSTNAME=$(kubectl get --namespace {{(first .Values.httpRoute.parentRefs).namespace | default .Release.Namespace }} gateway/{{ (first .Values.httpRoute.parentRefs).name }} -o jsonpath="{.spec.listeners[0].hostname}")
+  {{- end }}
+{{- if and .Values.httpRoute.rules (first .Values.httpRoute.rules).matches (first (first .Values.httpRoute.rules).matches).path.value }}
+    echo "Visit http://$APP_HOSTNAME{{ (first (first .Values.httpRoute.rules).matches).path.value }} to use your application"
+
+    NOTE: Your HTTPRoute depends on the listener configuration of your gateway and your HTTPRoute rules.
+    The rules can be set for path, method, header and query parameters.
+    You can check the gateway configuration with 'kubectl get --namespace {{(first .Values.httpRoute.parentRefs).namespace | default .Release.Namespace }} gateway/{{ (first .Values.httpRoute.parentRefs).name }} -o yaml'
+{{- end }}
+{{- else if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "deda.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "deda.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "deda.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "deda.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/helm/deda/templates/_helpers.tpl
+++ b/helm/deda/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "deda.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "deda.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "deda.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "deda.labels" -}}
+helm.sh/chart: {{ include "deda.chart" . }}
+{{ include "deda.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "deda.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "deda.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "deda.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "deda.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/deda/templates/deployment.yaml
+++ b/helm/deda/templates/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "deda.fullname" . }}
+  labels:
+    {{- include "deda.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "deda.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "deda.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "deda.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/deda/templates/hpa.yaml
+++ b/helm/deda/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "deda.fullname" . }}
+  labels:
+    {{- include "deda.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "deda.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/deda/templates/httproute.yaml
+++ b/helm/deda/templates/httproute.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "deda.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "deda.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httpRoute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/helm/deda/templates/ingress.yaml
+++ b/helm/deda/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "deda.fullname" . }}
+  labels:
+    {{- include "deda.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "deda.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/deda/templates/service.yaml
+++ b/helm/deda/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "deda.fullname" . }}
+  labels:
+    {{- include "deda.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "deda.selectorLabels" . | nindent 4 }}

--- a/helm/deda/templates/serviceaccount.yaml
+++ b/helm/deda/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "deda.serviceAccountName" . }}
+  labels:
+    {{- include "deda.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm/deda/templates/tests/test-connection.yaml
+++ b/helm/deda/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "deda.fullname" . }}-test-connection"
+  labels:
+    {{- include "deda.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "deda.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/helm/deda/values.yaml
+++ b/helm/deda/values.yaml
@@ -1,0 +1,151 @@
+# Default values for deda.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: deda
+  # This sets the pull policy for images.
+  pullPolicy: Never
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 80
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# -- Expose the service via gateway-api HTTPRoute
+# Requires Gateway API resources and suitable controller installed within the cluster
+# (see: https://gateway-api.sigs.k8s.io/guides/)
+httpRoute:
+  # HTTPRoute enabled.
+  enabled: false
+  # HTTPRoute annotations.
+  annotations: {}
+  # Which Gateways this Route is attached to.
+  parentRefs:
+  - name: gateway
+    sectionName: http
+    # namespace: default
+  # Hostnames matching HTTP header.
+  hostnames:
+  - chart-example.local
+  # List of rules and filters applied.
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /headers
+  #   filters:
+  #   - type: RequestHeaderModifier
+  #     requestHeaderModifier:
+  #       set:
+  #       - name: My-Overwrite-Header
+  #         value: this-is-the-only-value
+  #       remove:
+  #       - User-Agent
+  # - matches:
+  #   - path:
+  #       type: PathPrefix
+  #       value: /echo
+  #     headers:
+  #     - name: version
+  #       value: v2
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Please follow the README.

**Description:**

Introduced Helm chart for deploying DEDA.

Simplifies local and cluster-based setup (including KIND).

Supports environment-based client startup via RUN_CLIENT.

Verified deployment using helm install deda ./deda.